### PR TITLE
Issue #2898451 by Mohammed J. Razem: Vardoc Search is requiring Core …

### DIFF
--- a/modules/vardoc_features/vardoc_search/vardoc_search.features.yml
+++ b/modules/vardoc_features/vardoc_search/vardoc_search.features.yml
@@ -1,5 +1,4 @@
 bundle: vardoc
 excluded:
   - core.entity_view_display.node.book.search_result
-  - ultimate_cron.job.search_cron
 required: true

--- a/modules/vardoc_features/vardoc_search/vardoc_search.info.yml
+++ b/modules/vardoc_features/vardoc_search/vardoc_search.info.yml
@@ -12,7 +12,6 @@ dependencies:
   - ds
   - node
   - panelizer
-  - search
   - search_api
   - search_api_db
   - system


### PR DESCRIPTION
…"Search" module - while it should only use Search API